### PR TITLE
Improved performance for MonthConfig#generateUnboundedMonths

### DIFF
--- a/library/src/main/java/com/kizitonwose/calendarview/model/MonthConfig.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/model/MonthConfig.kt
@@ -109,12 +109,8 @@ internal data class MonthConfig(
 
             val calendarMonths = mutableListOf<CalendarMonth>()
             val calMonthsCount = allDaysGroup.size roundDiv maxRowCount
-            while (allDaysGroup.isNotEmpty()) {
-                val monthWeeks = allDaysGroup.take(maxRowCount).toMutableList()
-
-                // Keep a copy so after adding outDates to the last month, we can still remove
-                // it from allDaysGroup and allDaysGroup.isNotEmpty() will be true.
-                val monthWeeksCopy = allDaysGroup.take(maxRowCount).toMutableList()
+            allDaysGroup.chunked(maxRowCount) { curMonthWeeks ->
+                val monthWeeks = ArrayList(curMonthWeeks)
 
                 // Add the outDates for the last row if needed.
                 if (monthWeeks.last().size < 7 && outDateStyle == OutDateStyle.END_OF_ROW || outDateStyle == OutDateStyle.END_OF_GRID) {
@@ -183,7 +179,6 @@ internal data class MonthConfig(
                     // indexInSameMonth is basically this item's index in the entire month list.
                     CalendarMonth(startMonth, monthWeeks, calendarMonths.size, calMonthsCount)
                 )
-                allDaysGroup.removeAll(monthWeeksCopy)
             }
 
             return calendarMonths


### PR DESCRIPTION
I profiled the calendar rendering and noticed that MonthConfig works slow in the place which I fixed.

I checked that after this fix rendering became faster.