### PR TITLE
#183 Removing redundant linear layout. 

### DIFF
--- a/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarAdapter.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarAdapter.kt
@@ -37,9 +37,6 @@ internal class CalendarAdapter(
     private val months: List<CalendarMonth>
         get() = monthConfig.months
 
-    val bodyViewId = ViewCompat.generateViewId()
-    val rootViewId = ViewCompat.generateViewId()
-
     // Values of headerViewId & footerViewId will be
     // replaced with IDs set in the XML if present.
     var headerViewId = ViewCompat.generateViewId()
@@ -66,7 +63,6 @@ internal class CalendarAdapter(
         val context = parent.context
         val rootLayout = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
-            id = rootViewId
         }
 
         if (viewConfig.monthHeaderRes != 0) {
@@ -80,12 +76,14 @@ internal class CalendarAdapter(
             rootLayout.addView(monthHeaderView)
         }
 
-        val monthBodyLayout = LinearLayout(context).apply {
-            layoutParams = LinearLayout.LayoutParams(LP.WRAP_CONTENT, LP.WRAP_CONTENT)
-            orientation = LinearLayout.VERTICAL
-            id = bodyViewId
-        }
-        rootLayout.addView(monthBodyLayout)
+        @Suppress("UNCHECKED_CAST") val dayConfig = DayConfig(
+            calView.dayWidth, calView.dayHeight, viewConfig.dayViewRes,
+            calView.dayBinder as DayBinder<ViewContainer>
+        )
+
+        val weekHolders = (1..6)
+            .map { WeekHolder(createDayHolders(dayConfig)) }
+            .onEach { weekHolder -> rootLayout.addView(weekHolder.inflateWeekView(rootLayout)) }
 
         if (viewConfig.monthFooterRes != 0) {
             val monthFooterView = rootLayout.inflate(viewConfig.monthFooterRes)
@@ -130,15 +128,15 @@ internal class CalendarAdapter(
 
         @Suppress("UNCHECKED_CAST")
         return MonthViewHolder(
-            this, userRoot,
-            DayConfig(
-                calView.dayWidth, calView.dayHeight, viewConfig.dayViewRes,
-                calView.dayBinder as DayBinder<ViewContainer>
-            ),
+            this,
+            userRoot,
+            weekHolders,
             calView.monthHeaderBinder as MonthHeaderFooterBinder<ViewContainer>?,
             calView.monthFooterBinder as MonthHeaderFooterBinder<ViewContainer>?
         )
     }
+
+    private fun createDayHolders(dayConfig: DayConfig) = (1..7).map { DayHolder(dayConfig) }
 
     override fun onBindViewHolder(holder: MonthViewHolder, position: Int, payloads: List<Any>) {
         if (payloads.isEmpty()) {

--- a/library/src/main/java/com/kizitonwose/calendarview/ui/DayHolder.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/DayHolder.kt
@@ -6,6 +6,8 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.annotation.LayoutRes
 import androidx.annotation.Px
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import com.kizitonwose.calendarview.model.CalendarDay
 import com.kizitonwose.calendarview.utils.inflate
 
@@ -55,12 +57,12 @@ internal class DayHolder(private val config: DayConfig) {
         }
 
         if (currentDay != null) {
-            if (containerView.visibility != View.VISIBLE) {
-                containerView.visibility = View.VISIBLE
+            if (!containerView.isVisible) {
+                containerView.isVisible = true
             }
             config.viewBinder.bind(viewContainer, currentDay)
-        } else if (containerView.visibility != View.GONE) {
-            containerView.visibility = View.GONE
+        } else if (!containerView.isGone) {
+            containerView.isGone = true
         }
     }
 

--- a/library/src/main/java/com/kizitonwose/calendarview/ui/MonthViewHolder.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/MonthViewHolder.kt
@@ -42,6 +42,6 @@ internal class MonthViewHolder constructor(
     }
 
     fun reloadDay(day: CalendarDay) {
-        weekHolders.map { it.dayHolders }.flatten().firstOrNull { it.day == day }?.reloadView()
+        weekHolders.flatMap { it.dayHolders }.firstOrNull { it.day == day }?.reloadView()
     }
 }

--- a/library/src/main/java/com/kizitonwose/calendarview/ui/MonthViewHolder.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/MonthViewHolder.kt
@@ -2,7 +2,6 @@ package com.kizitonwose.calendarview.ui
 
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.kizitonwose.calendarview.model.CalendarDay
 import com.kizitonwose.calendarview.model.CalendarMonth
@@ -10,28 +9,18 @@ import com.kizitonwose.calendarview.model.CalendarMonth
 internal class MonthViewHolder constructor(
     adapter: CalendarAdapter,
     rootLayout: ViewGroup,
-    dayConfig: DayConfig,
+    private val weekHolders: List<WeekHolder>,
     private var monthHeaderBinder: MonthHeaderFooterBinder<ViewContainer>?,
     private var monthFooterBinder: MonthHeaderFooterBinder<ViewContainer>?
 ) : RecyclerView.ViewHolder(rootLayout) {
 
-    private val weekHolders = (1..6).map { WeekHolder(dayConfig) }
-
     val headerView: View? = rootLayout.findViewById(adapter.headerViewId)
     val footerView: View? = rootLayout.findViewById(adapter.footerViewId)
-    val bodyLayout: LinearLayout = rootLayout.findViewById(adapter.bodyViewId)
 
     private var headerContainer: ViewContainer? = null
     private var footerContainer: ViewContainer? = null
 
     lateinit var month: CalendarMonth
-
-    init {
-        // Add week rows.
-        weekHolders.forEach {
-            bodyLayout.addView(it.inflateWeekView(bodyLayout))
-        }
-    }
 
     fun bindMonth(month: CalendarMonth) {
         this.month = month

--- a/library/src/main/java/com/kizitonwose/calendarview/ui/WeekHolder.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/WeekHolder.kt
@@ -5,9 +5,7 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import com.kizitonwose.calendarview.model.CalendarDay
 
-internal class WeekHolder(dayConfig: DayConfig) {
-
-    val dayHolders = (1..7).map { DayHolder(dayConfig) }
+internal class WeekHolder(val dayHolders: List<DayHolder>) {
 
     private lateinit var container: LinearLayout
 

--- a/library/src/main/java/com/kizitonwose/calendarview/ui/WeekHolder.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/WeekHolder.kt
@@ -3,6 +3,7 @@ package com.kizitonwose.calendarview.ui
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.core.view.isGone
 import com.kizitonwose.calendarview.model.CalendarDay
 
 internal class WeekHolder(val dayHolders: List<DayHolder>) {
@@ -25,7 +26,7 @@ internal class WeekHolder(val dayHolders: List<DayHolder>) {
     }
 
     fun bindWeekView(daysOfWeek: List<CalendarDay>) {
-        container.visibility = if (daysOfWeek.isEmpty()) View.GONE else View.VISIBLE
+        container.isGone = daysOfWeek.isEmpty()
         dayHolders.forEachIndexed { index, holder ->
             // Indices can be null if OutDateStyle is NONE. We set the
             // visibility for the views at these indices to INVISIBLE.


### PR DESCRIPTION
In order to preserve the order of views added to the rootLayout, inflation of week and day views was moved to the main onCreateViewHolder method. Moving all inflation to onCreateViewHolder (from the constructor of MonthViewHolder) also allows us to remove the DayConfig dependency from MonthViewHolder and WeekViewHolder as these classes don't actually need it.