### PR TITLE
Notify MonthListener when scrolling to a specific date with scrollToDate()

### DIFF
--- a/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarLayoutManager.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarLayoutManager.kt
@@ -46,6 +46,7 @@ internal class CalendarLayoutManager(private val calView: CalendarView, @Recycle
     fun scrollToDay(day: CalendarDay) {
         val monthPosition = adapter.getAdapterPosition(day)
         scrollToPositionWithOffset(monthPosition, 0)
+        calView.post { adapter.notifyMonthScrollListenerIfNeeded() }
         // Can't target a specific day in a paged calendar.
         if (calView.scrollMode == ScrollMode.PAGED) return
         calView.post {
@@ -54,7 +55,6 @@ internal class CalendarLayoutManager(private val calView: CalendarView, @Recycle
                     calView.findViewHolderForAdapterPosition(monthPosition) as? MonthViewHolder ?: return@post
                 val offset = calculateDayViewOffsetInParent(day, viewHolder.itemView)
                 scrollToPositionWithOffset(monthPosition, -offset)
-                calView.post { adapter.notifyMonthScrollListenerIfNeeded() }
             }
         }
     }

--- a/sample/src/androidTest/java/com/kizitonwose/calenderviewsample/CalenderViewTests.kt
+++ b/sample/src/androidTest/java/com/kizitonwose/calenderviewsample/CalenderViewTests.kt
@@ -45,6 +45,7 @@ class CalenderViewTests {
     val homeScreenRule = ActivityTestRule(HomeActivity::class.java, true, false)
 
     private val currentMonth = YearMonth.now()
+    private val today = LocalDate.now()
 
     @Before
     fun setup() {
@@ -222,6 +223,28 @@ class CalenderViewTests {
         sleep(5000) // Enough time for smooth scrolling animation.
 
         assertEquals(targetCalMonth?.yearMonth, targetMonth)
+    }
+
+    @Test
+    fun monthScrollListenerIsCalledWhenScrolledToDate() {
+        onView(withId(R.id.examplesRv)).perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        val calendarView = findFragment<Example1Fragment>().findViewById<CalendarView>(R.id.exOneCalendar)
+
+        val targetDay = today.plusDays(60)
+
+        var targetCalMonth: CalendarMonth? = null
+        calendarView.monthScrollListener = { month ->
+            targetCalMonth = month
+        }
+
+        homeScreenRule.runOnUiThread {
+            calendarView.scrollToDate(targetDay)
+        }
+
+        sleep(5000) // Enough time for smooth scrolling animation.
+
+        assertEquals(targetDay.yearMonth, targetCalMonth?.yearMonth)
     }
 
     @Test

--- a/sample/src/main/java/com/kizitonwose/calendarviewsample/Example1Fragment.kt
+++ b/sample/src/main/java/com/kizitonwose/calendarviewsample/Example1Fragment.kt
@@ -189,6 +189,10 @@ class Example1Fragment : BaseFragment(R.layout.example_1_fragment), HasToolbar {
             animator.duration = 250
             animator.start()
         }
+
+        binding.todayButton.setOnClickListener {
+            binding.exOneCalendar.scrollToDate(LocalDate.now())
+        }
     }
 
     override fun onStart() {

--- a/sample/src/main/res/layout/example_1_fragment.xml
+++ b/sample/src/main/res/layout/example_1_fragment.xml
@@ -78,6 +78,16 @@
             android:textSize="18sp"
             android:layout_gravity="bottom|center_horizontal" />
 
+        <Button
+            android:id="@+id/todayButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/today"
+            android:textSize="18sp"
+            android:layout_gravity="bottom|center_horizontal"
+            android:layout_marginBottom="86dp"
+            style="@style/Widget.AppCompat.Button.Borderless"/>
+
     </FrameLayout>
 
 

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -24,5 +24,6 @@
     <string name="end_date">End date</string>
     <string name="clear">Clear</string>
     <string name="week_mode">Week mode</string>
+    <string name="today">Today</string>
 
 </resources>


### PR DESCRIPTION
The month listener is only being called right now if the calendar is not in paged mode, but we need to update the month even in paged mode. This can be demonstrated in the sample app using the "Today" button that I added to example1.