### PR TITLE
Auto day width, custom height

### DIFF
--- a/library/src/main/java/com/kizitonwose/calendarview/CalendarView.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/CalendarView.kt
@@ -289,10 +289,16 @@ open class CalendarView : RecyclerView {
 
             // +0.5 => round to the nearest pixel
             val size = (((widthSize - (monthPaddingStart + monthPaddingEnd)) / 7f) + 0.5).toInt()
-            val squareSize = daySize.copy(width = size, height = size)
-            if (daySize != squareSize) {
+
+            val computedSize = when {
+                daySize == SIZE_SQUARE -> daySize.copy(width = size, height = size)
+                daySize.width == DAY_SIZE_SQUARE -> daySize.copy(width = size)
+                else -> throw IllegalStateException("Autosize is true but daySize is neither SIZE_SQUARE nor is daySize.width DAY_SIZE_SQUARE")
+            }
+
+            if (daySize != computedSize) {
                 sizedInternally = true
-                daySize = squareSize
+                daySize = computedSize
                 sizedInternally = false
                 invalidateViewHolders()
             }
@@ -349,7 +355,7 @@ open class CalendarView : RecyclerView {
         set(value) {
             field = value
             if (!sizedInternally) {
-                autoSize = value == SIZE_SQUARE
+                autoSize = value == SIZE_SQUARE || value.width == DAY_SIZE_SQUARE
                 invalidateViewHolders()
             }
         }

--- a/library/src/main/java/com/kizitonwose/calendarview/CalendarView.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/CalendarView.kt
@@ -293,7 +293,7 @@ open class CalendarView : RecyclerView {
             val computedSize = when {
                 daySize == SIZE_SQUARE -> daySize.copy(width = size, height = size)
                 daySize.width == DAY_SIZE_SQUARE -> daySize.copy(width = size)
-                else -> throw IllegalStateException("Autosize is true but daySize is neither SIZE_SQUARE nor is daySize.width DAY_SIZE_SQUARE")
+                else -> daySize
             }
 
             if (daySize != computedSize) {

--- a/library/src/main/java/com/kizitonwose/calendarview/CalendarView.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/CalendarView.kt
@@ -962,5 +962,11 @@ open class CalendarView : RecyclerView {
          * be the width of the calender divided by 7.
          */
         val SIZE_SQUARE = Size(DAY_SIZE_SQUARE, DAY_SIZE_SQUARE)
+
+        /**
+         * A value for [daySize] which indicates that the day cells should
+         * have width of the calender divided by 7 and provided height.
+         */
+        fun sizeAutoWidth(@Px height: Int) = Size(DAY_SIZE_SQUARE, height)
     }
 }


### PR DESCRIPTION
Hi, firstly, thanks for this awesome library!
I found myself in a situation that I wanted day cell to have an automatic width to span the whole calendar width, but custom height at the same time. That was not possible with the library and even though it is possible to achieve that from the application, it might be quite difficult, whereas it is easy to do so in the library. So I created this fix for myself and I think others might find it useful as well.