### PR TITLE
Remove deprecated adapterPosition

### DIFF
--- a/sample/src/main/java/com/kizitonwose/calendarviewsample/Example3Fragment.kt
+++ b/sample/src/main/java/com/kizitonwose/calendarviewsample/Example3Fragment.kt
@@ -55,7 +55,7 @@ class Example3EventsAdapter(val onClick: (Event) -> Unit) :
 
         init {
             itemView.setOnClickListener {
-                onClick(events[adapterPosition])
+                onClick(events[bindingAdapterPosition])
             }
         }
 

--- a/sample/src/main/java/com/kizitonwose/calendarviewsample/HomeOptionsAdapter.kt
+++ b/sample/src/main/java/com/kizitonwose/calendarviewsample/HomeOptionsAdapter.kt
@@ -41,7 +41,7 @@ class HomeOptionsAdapter(val onClick: (ExampleItem) -> Unit) :
 
         init {
             itemView.setOnClickListener {
-                onClick(examples[adapterPosition])
+                onClick(examples[bindingAdapterPosition])
             }
         }
 


### PR DESCRIPTION
From RecyclerView's documentation:
```java
        /**
         * @return {@link #getBindingAdapterPosition()}
         * @deprecated This method is confusing when adapters nest other adapters.
         * If you are calling this in the context of an Adapter, you probably want to call
         * {@link #getBindingAdapterPosition()} or if you want the position as {@link RecyclerView}
         * sees it, you should call {@link #getAbsoluteAdapterPosition()}.
         */

        @Deprecated
        public final int getAdapterPosition() {
            return getBindingAdapterPosition();
        }
```

This PR replaces `getAdapterPosition` with `getBindingAdapterPosition`.