### PR TITLE
Account for margins in calculating animation height

### DIFF
--- a/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarAdapter.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarAdapter.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.annotation.LayoutRes
-import androidx.core.view.MarginLayoutParamsCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.RecyclerView

--- a/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarAdapter.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarAdapter.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.annotation.LayoutRes
+import androidx.core.view.MarginLayoutParamsCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.RecyclerView
@@ -217,11 +218,13 @@ internal class CalendarAdapter(
                     val visibleVH =
                         calView.findViewHolderForAdapterPosition(visibleItemPos) as? MonthViewHolder ?: return
                     val newHeight = visibleVH.headerView?.height.orZero() +
+                            visibleVH.headerView?.getMarginHeight().orZero() +
                             // visibleVH.bodyLayout.height` won't not give us the right height as it differs
                             // depending on row count in the month. So we calculate the appropriate height
                             // by checking the number of visible(non-empty) rows.
                             visibleMonth.weekDays.size * calView.daySize.height +
-                            visibleVH.footerView?.height.orZero()
+                            visibleVH.footerView?.height.orZero() +
+                            visibleVH.footerView?.getMarginHeight().orZero()
                     if (calView.height != newHeight) {
                         ValueAnimator.ofInt(calView.height, newHeight).apply {
                             // Don't animate when the view is shown initially.
@@ -280,6 +283,11 @@ internal class CalendarAdapter(
     fun findFirstVisibleDay(): CalendarDay? = findVisibleDay(true)
 
     fun findLastVisibleDay(): CalendarDay? = findVisibleDay(false)
+
+    private fun View.getMarginHeight(): Int {
+        val marginParams = layoutParams as? ViewGroup.MarginLayoutParams
+        return marginParams?.topMargin.orZero() + marginParams?.bottomMargin.orZero()
+    }
 
     private fun findFirstVisibleMonthPosition(): Int = findVisibleMonthPosition(true)
 

--- a/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarAdapter.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarAdapter.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.kizitonwose.calendarview.CalendarView
 import com.kizitonwose.calendarview.model.*
 import com.kizitonwose.calendarview.utils.NO_INDEX
+import com.kizitonwose.calendarview.utils.getVerticalMargins
 import com.kizitonwose.calendarview.utils.inflate
 import com.kizitonwose.calendarview.utils.orZero
 import java.time.LocalDate
@@ -217,13 +218,13 @@ internal class CalendarAdapter(
                     val visibleVH =
                         calView.findViewHolderForAdapterPosition(visibleItemPos) as? MonthViewHolder ?: return
                     val newHeight = visibleVH.headerView?.height.orZero() +
-                            visibleVH.headerView?.getMarginHeight().orZero() +
+                            visibleVH.headerView?.getVerticalMargins().orZero() +
                             // visibleVH.bodyLayout.height` won't not give us the right height as it differs
                             // depending on row count in the month. So we calculate the appropriate height
                             // by checking the number of visible(non-empty) rows.
                             visibleMonth.weekDays.size * calView.daySize.height +
                             visibleVH.footerView?.height.orZero() +
-                            visibleVH.footerView?.getMarginHeight().orZero()
+                            visibleVH.footerView?.getVerticalMargins().orZero()
                     if (calView.height != newHeight) {
                         ValueAnimator.ofInt(calView.height, newHeight).apply {
                             // Don't animate when the view is shown initially.
@@ -282,11 +283,6 @@ internal class CalendarAdapter(
     fun findFirstVisibleDay(): CalendarDay? = findVisibleDay(true)
 
     fun findLastVisibleDay(): CalendarDay? = findVisibleDay(false)
-
-    private fun View.getMarginHeight(): Int {
-        val marginParams = layoutParams as? ViewGroup.MarginLayoutParams
-        return marginParams?.topMargin.orZero() + marginParams?.bottomMargin.orZero()
-    }
 
     private fun findFirstVisibleMonthPosition(): Int = findVisibleMonthPosition(true)
 

--- a/library/src/main/java/com/kizitonwose/calendarview/utils/Extensions.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/utils/Extensions.kt
@@ -34,3 +34,8 @@ internal val Rect.namedString: String
 
 internal val CoroutineScope.job: Job
     get() = requireNotNull(coroutineContext[Job])
+
+internal fun View.getVerticalMargins(): Int {
+    val marginParams = layoutParams as? ViewGroup.MarginLayoutParams
+    return marginParams?.topMargin.orZero() + marginParams?.bottomMargin.orZero()
+}


### PR DESCRIPTION
Working on incorporating this view for the Airtable app; it turns out, the height calculation for the animation when swiping between months is missing the calculations for the margins on the header and footer. This adds these values to the calculation.